### PR TITLE
Add ext-curl requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "require-dev" : {
     "php": ">=5.4",
+    "ext-curl": "*",
     "symfony/http-kernel": ">=2.1",
     "symfony/dependency-injection": ">=2.1",
     "symfony/config": ">=2.1",


### PR DESCRIPTION
Avoid unhandled error message "ContextErrorException in CircleRestClientExtension.php line 54: Warning: constant(): Couldn't find constant CURLOPT_HTTPHEADER" when php-curl is not installed.